### PR TITLE
Remove argument spaces

### DIFF
--- a/lib/ping.js
+++ b/lib/ping.js
@@ -24,9 +24,9 @@ function probe(addr, config, callback) {
         args = [];
         if (config.numeric  !== false) args.push('-n');
 
-        if (config.timeout  !== false) args.push('-w ' + config.timeout);
+        if (config.timeout  !== false) args.push('-w' + config.timeout);
 
-        if (config.minReply !== false) args.push('-c ' + config.minReply);
+        if (config.minReply !== false) args.push('-c' + config.minReply);
 
         if (config.extra    !== false) args = args.concat(config.extra);
 


### PR DESCRIPTION
On alpine linux the space in the argument causes the issue:
```
ping: invalid number ' 2'
```
As all other versions of ping should work without spaces best thing is to just remove them.